### PR TITLE
Hugo error is now more specified

### DIFF
--- a/cmd/midasd/main.go
+++ b/cmd/midasd/main.go
@@ -219,8 +219,6 @@ func rollbarError(ctx context.Context, err error, args ...interface{}) {
 		rollbar.ClearPerson()
 	}
 
-	log.Printf("error: %+v\n", err)
-
 	if len(args) > 0 {
 		rollbar.Error(append([]interface{}{err}, args...)...)
 	} else {

--- a/http/http.go
+++ b/http/http.go
@@ -17,6 +17,8 @@ func Error(w http.ResponseWriter, r *http.Request, err error) {
 		log := httplog.LogEntry(r.Context())
 		log.Error().Msgf("internal server error: %+v", err)
 		midas.ReportError(r.Context(), err, r)
+
+		message = "Internal server error" // We don't want the error to be displayed for the enduser
 	}
 
 	jsonError, _ := json.Marshal(&ErrorResponse{Error: message})

--- a/hugo/site.go
+++ b/hugo/site.go
@@ -20,12 +20,12 @@ func NewSiteService(config midas.Site) midas.SiteService {
 }
 
 func (SiteService) GetRegistry() (string, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (SiteService) CreateRegistry() (string, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
@@ -41,9 +41,9 @@ func (s SiteService) BuildSite(useCache bool) error {
 	cmd := exec.Command("hugo", arg)
 	cmd.Dir = s.Site.RootDir
 
-	_, err := cmd.Output() // ToDo: display output somewhere
+	out, err := cmd.Output()
 	if err != nil {
-		return err
+		return midas.Errorf(midas.ErrInternal, "hugo build errored: %s\ncommand output: %s", err, out)
 	}
 
 	return nil
@@ -83,11 +83,11 @@ func (s SiteService) CreateEntry(payload midas.Payload) (string, error) {
 }
 
 func (SiteService) UpdateEntry(payload midas.Payload) (string, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (SiteService) RemoveEntry(payload midas.Payload) (string, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }


### PR DESCRIPTION
Hugo build error now returns fully specified `ErrInternal` with error and command output instead of sheer error message (which was just exit code)