### PR TITLE
Method to build drafts in separate directory

### DIFF
--- a/site.go
+++ b/site.go
@@ -3,10 +3,17 @@ package midas
 type Site struct {
 	SiteName        string                   `json:"siteName"`
 	RootDir         string                   `json:"rootDir"`
+	OutputSettings  OutputSettings           `json:"outputSettings"`
+	BuildDrafts     bool                     `json:"buildDrafts"`
 	Service         string                   `json:"service"`
 	Registry        RegistrySettings         `json:"registry"`
 	CollectionTypes map[string]ModelSettings `json:"collectionTypes"`
 	SingleTypes     map[string]ModelSettings `json:"singleTypes"`
+}
+
+type OutputSettings struct {
+	Build string `json:"build,omitempty"`
+	Draft string `json:"draft,omitempty"`
 }
 
 type ModelSettings struct {

--- a/site.go
+++ b/site.go
@@ -5,6 +5,7 @@ type Site struct {
 	RootDir         string                   `json:"rootDir"`
 	OutputSettings  OutputSettings           `json:"outputSettings"`
 	BuildDrafts     bool                     `json:"buildDrafts"`
+	DraftsUrl       string                   `json:"draftsUrl"`
 	Service         string                   `json:"service"`
 	Registry        RegistrySettings         `json:"registry"`
 	CollectionTypes map[string]ModelSettings `json:"collectionTypes"`


### PR DESCRIPTION
## Added
- Method for building Hugo sites with enabled drafts, expired and future content, in separate directory (so can be turned into separate preview page)
- Site config fields
  - `buildDrafts` (bool) - if true the draft version of page will be built alongside with the main build
  - `draftsUrl` (string/url) - url at which the draft site will be exposed (used i.e. for links generation)
  - `outputSettings` (object) - defining destinations where site should be exported (built): `build` for main site, `draft` for draft page
[Building draft site in separate directory](https://app.gitkraken.com/glo/card/5b3d8e7af4514837badbd29b03e840f5)