### PR TITLE
[Hugo] single types sanitizing and loading to json

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kovansky/midas
 
-go 1.17
+go 1.18
 
 require (
 	github.com/go-chi/chi/v5 v5.0.7

--- a/go.sum
+++ b/go.sum
@@ -38,7 +38,6 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -23,6 +23,7 @@ var (
 		"CreateEntry":        0,
 		"UpdateEntry":        0,
 		"DeleteEntry":        0,
+		"UpdateSingle":       0,
 	}
 	MockRegistryCounters = map[string]int{
 		"OpenStorage":   0,
@@ -133,6 +134,11 @@ func SetUp(t *testing.T) *Server {
 				MockSiteCounters["GetRegistryService"]++
 
 				return prepareMockRegistryService(site), nil
+			}
+			siteService.UpdateSingleFn = func(_ midas.Payload) (string, error) {
+				MockSiteCounters["UpdateSingle"]++
+
+				return "", nil
 			}
 
 			return siteService, nil

--- a/http/strapi-hugo.go
+++ b/http/strapi-hugo.go
@@ -11,13 +11,14 @@ import (
 	"errors"
 	"github.com/go-chi/chi/v5"
 	"github.com/kovansky/midas"
+	"github.com/kovansky/midas/hugo"
 	"github.com/kovansky/midas/strapi"
 	"io"
 	"net/http"
 )
 
 type StrapiToHugoHandler struct {
-	HugoSite midas.SiteService
+	HugoSite hugo.SiteService
 	Payload  midas.Payload
 }
 
@@ -64,7 +65,7 @@ func (s *Server) handleStrapiToHugo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	handler := &StrapiToHugoHandler{
-		HugoSite: hugoSite,
+		HugoSite: hugoSite.(hugo.SiteService),
 		Payload:  payload,
 	}
 	defer func() {
@@ -166,12 +167,17 @@ func (h StrapiToHugoHandler) Handle(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h StrapiToHugoHandler) handleCreateSingle(w http.ResponseWriter, r *http.Request) {
+	if _, err := h.HugoSite.UpdateSingle(h.Payload); err != nil {
+		Error(w, r, err)
+		return
+	}
+
 	if err := h.HugoSite.BuildSite(true); err != nil {
 		Error(w, r, err)
 		return
 	}
 
-	w.WriteHeader(http.StatusNoContent)
+	w.WriteHeader(http.StatusCreated)
 }
 
 func (h StrapiToHugoHandler) handleCreateCollection(w http.ResponseWriter, r *http.Request) {
@@ -189,12 +195,17 @@ func (h StrapiToHugoHandler) handleCreateCollection(w http.ResponseWriter, r *ht
 }
 
 func (h StrapiToHugoHandler) handleUpdateSingle(w http.ResponseWriter, r *http.Request) {
+	if _, err := h.HugoSite.UpdateSingle(h.Payload); err != nil {
+		Error(w, r, err)
+		return
+	}
+
 	if err := h.HugoSite.BuildSite(false); err != nil {
 		Error(w, r, err)
 		return
 	}
 
-	w.WriteHeader(http.StatusNoContent)
+	w.WriteHeader(http.StatusCreated)
 }
 
 func (h StrapiToHugoHandler) handleUpdateCollection(w http.ResponseWriter, r *http.Request) {

--- a/http/strapi-hugo.go
+++ b/http/strapi-hugo.go
@@ -11,14 +11,13 @@ import (
 	"errors"
 	"github.com/go-chi/chi/v5"
 	"github.com/kovansky/midas"
-	"github.com/kovansky/midas/hugo"
 	"github.com/kovansky/midas/strapi"
 	"io"
 	"net/http"
 )
 
 type StrapiToHugoHandler struct {
-	HugoSite hugo.SiteService
+	HugoSite midas.SiteService
 	Payload  midas.Payload
 }
 
@@ -65,7 +64,7 @@ func (s *Server) handleStrapiToHugo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	handler := &StrapiToHugoHandler{
-		HugoSite: hugoSite.(hugo.SiteService),
+		HugoSite: hugoSite,
 		Payload:  payload,
 	}
 	defer func() {
@@ -177,7 +176,7 @@ func (h StrapiToHugoHandler) handleCreateSingle(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	w.WriteHeader(http.StatusCreated)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h StrapiToHugoHandler) handleCreateCollection(w http.ResponseWriter, r *http.Request) {
@@ -205,7 +204,7 @@ func (h StrapiToHugoHandler) handleUpdateSingle(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	w.WriteHeader(http.StatusCreated)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h StrapiToHugoHandler) handleUpdateCollection(w http.ResponseWriter, r *http.Request) {

--- a/http/strapi-hugo_test.go
+++ b/http/strapi-hugo_test.go
@@ -126,8 +126,9 @@ func TestStrapiToHugoHandler_Handle(t *testing.T) {
 			}
 
 			testing_utils.AssertTable(t, map[string][]interface{}{
-				"Status code":    {resp.StatusCode, http.StatusNoContent},
-				"Site.BuildSite": {MockSiteCounters["BuildSite"], 1},
+				"Status code":       {resp.StatusCode, http.StatusNoContent},
+				"Site.UpdateSingle": {MockSiteCounters["UpdateSingle"], 1},
+				"Site.BuildSite":    {MockSiteCounters["BuildSite"], 1},
 			})
 		})
 
@@ -185,8 +186,9 @@ func TestStrapiToHugoHandler_Handle(t *testing.T) {
 			}
 
 			testing_utils.AssertTable(t, map[string][]interface{}{
-				"Status code":    {resp.StatusCode, http.StatusNoContent},
-				"Site.BuildSite": {MockSiteCounters["BuildSite"], 1},
+				"Status code":       {resp.StatusCode, http.StatusNoContent},
+				"Site.UpdateSingle": {MockSiteCounters["UpdateSingle"], 1},
+				"Site.BuildSite":    {MockSiteCounters["BuildSite"], 1},
 			})
 		})
 

--- a/mock/site.go
+++ b/mock/site.go
@@ -17,6 +17,7 @@ type SiteService struct {
 	CreateEntryFn        func(payload midas.Payload) (string, error)
 	UpdateEntryFn        func(payload midas.Payload) (string, error)
 	DeleteEntryFn        func(payload midas.Payload) (string, error)
+	UpdateSingleFn       func(payload midas.Payload) (string, error)
 }
 
 func NewSiteService() *SiteService {
@@ -41,4 +42,8 @@ func (s *SiteService) UpdateEntry(payload midas.Payload) (string, error) {
 
 func (s *SiteService) DeleteEntry(payload midas.Payload) (string, error) {
 	return s.DeleteEntryFn(payload)
+}
+
+func (s *SiteService) UpdateSingle(payload midas.Payload) (string, error) {
+	return s.UpdateSingleFn(payload)
 }

--- a/payload.go
+++ b/payload.go
@@ -14,5 +14,6 @@ type Payload interface {
 	Event() string
 	Metadata() map[string]interface{}
 	Entry() map[string]interface{}
+	SetEntry(map[string]interface{})
 	Raw() interface{}
 }

--- a/payload.go
+++ b/payload.go
@@ -6,7 +6,11 @@
 
 package midas
 
+import "encoding/json"
+
 type Payload interface {
+	json.Unmarshaler
+	json.Marshaler
 	Event() string
 	Metadata() map[string]interface{}
 	Entry() map[string]interface{}

--- a/site.go
+++ b/site.go
@@ -39,4 +39,5 @@ type SiteService interface {
 	CreateEntry(payload Payload) (string, error)
 	UpdateEntry(payload Payload) (string, error)
 	DeleteEntry(payload Payload) (string, error)
+	UpdateSingle(payload Payload) (string, error)
 }

--- a/strapi/payload.go
+++ b/strapi/payload.go
@@ -62,6 +62,10 @@ func (p Payload) Entry() map[string]interface{} {
 	return p.entry
 }
 
+func (p Payload) SetEntry(entry map[string]interface{}) {
+	p.entry = entry
+}
+
 func (p Payload) Raw() interface{} {
 	return p
 }

--- a/strapi/payload.go
+++ b/strapi/payload.go
@@ -32,7 +32,7 @@ func ParsePayload(json []byte) (midas.Payload, error) {
 
 	payload.createMetadataMap()
 
-	return payload, nil
+	return &payload, nil
 }
 
 func (p Payload) Event() string {


### PR DESCRIPTION
## Changed
- Single types are now passed through HTML sanitizer and saved as json file to be used as data file
- `midas.SiteService` interface: added `UpdateSingle` function
  - `hugo.SiteService` implementation: added `UpdateSingle` function
  - `mock.SiteService` implementation: added `UpdateSingle` function
- `midas.Payload` interface: added `SetEntry` function
  - `strapi.Payload` implementation: added `SetEntry` function

Closes #29

[[hugo] Single types: load as json to data folder, run through HTML sanitizer](https://app.gitkraken.com/glo/card/ad8b6d66ee5740408227954b6999df0e)