### PR TITLE
Bump Go version in Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@v2
         with:
-          go-version: "^1.17"
+          go-version: "^1.18"
       - name: Build
         run: go build -v ./...
       - name: Run tests


### PR DESCRIPTION
## Changed
- Modified Go version in GitHub Actions from 1.17 to 1.18

Closes #36 