### PR TITLE
Fix tests (for fieldnames)

### DIFF
--- a/http/server_test.go
+++ b/http/server_test.go
@@ -151,7 +151,7 @@ func SetUp(t *testing.T) *Server {
 					Type: "mock",
 				},
 				CollectionTypes: map[string]midas.ModelSettings{
-					"post": {"./archetypes/archetype.md", "./out"},
+					"post": {ArchetypePath: "./archetypes/archetype.md", OutputDir: "./out"},
 				},
 				SingleTypes: map[string]midas.ModelSettings{
 					"homepage": {},

--- a/http/strapi-hugo.go
+++ b/http/strapi-hugo.go
@@ -64,6 +64,12 @@ func (s *Server) handleStrapiToHugo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	log.Info().Fields(map[string]interface{}{
+		"page":  cfg.SiteName,
+		"model": payload.Metadata()["model"],
+		"id":    payload.Entry()["id"],
+	}).Msg("Request data")
+
 	hugoSite, err := s.SiteServices["hugo"](*cfg)
 	if err != nil {
 		Error(w, r, err)
@@ -230,7 +236,7 @@ func (h StrapiToHugoHandler) handleUpdateSingle(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	if err := h.HugoSite.BuildSite(false); err != nil {
+	if err := h.HugoSite.BuildSite(true); err != nil {
 		Error(w, r, err)
 		return
 	}
@@ -249,7 +255,7 @@ func (h StrapiToHugoHandler) handleUpdateCollection(w http.ResponseWriter, r *ht
 		return
 	}
 
-	if err := h.HugoSite.BuildSite(false); err != nil {
+	if err := h.HugoSite.BuildSite(true); err != nil {
 		Error(w, r, err)
 		return
 	}

--- a/midas-config.schema.json
+++ b/midas-config.schema.json
@@ -104,6 +104,24 @@
                     "outputDir": {
                       "type": "string",
                       "description": "In which directory the entries of this type should be generated."
+                    },
+                    "fields": {
+                      "type": "object",
+                      "description": "Overwrite the names of the fields important for Midas.",
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "Field containing title. Used to generate slug and filename.",
+                          "default": "Title"
+                        },
+                        "html": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Fields that should be treated as HTML - therefore treated with sanitizer."
+                        }
+                      }
                     }
                   }
                 }


### PR DESCRIPTION
## Changed
- Cache policy - in update single and update collection actions in hugo don't ignore cache
- More details added to request log

## Fixed
- Tests (were broken by changes before

Closes #43 