### PR TITLE
[Fix] `continue` when error appear in `Client.RemoteFiles`

### DIFF
--- a/sftp/client.go
+++ b/sftp/client.go
@@ -117,6 +117,7 @@ func (c *Client) RemoteFiles() (walk.FileMap, []error) {
 	for walker.Step() {
 		if err := walker.Err(); err != nil {
 			errors = append(errors, err)
+			continue
 		}
 
 		stat := walker.Stat()


### PR DESCRIPTION
## Fixed
- Added `continue` statement on error occurrence in `sftp.Client.RemoteFiles` walker loop to prevent from app crashing