### PR TITLE
Feature/drafts environment

### DIFF
--- a/.idea/jsonSchemas.xml
+++ b/.idea/jsonSchemas.xml
@@ -3,6 +3,23 @@
   <component name="JsonSchemaMappingsProjectConfiguration">
     <state>
       <map>
+        <entry key="JSON Schema version 7">
+          <value>
+            <SchemaInfo>
+              <option name="name" value="JSON Schema version 7" />
+              <option name="relativePathToSchema" value="http://json-schema.org/draft-07/schema" />
+              <option name="schemaVersion" value="JSON Schema version 7" />
+              <option name="applicationDefined" value="true" />
+              <option name="patterns">
+                <list>
+                  <Item>
+                    <option name="path" value="midas-config.schema.json" />
+                  </Item>
+                </list>
+              </option>
+            </SchemaInfo>
+          </value>
+        </entry>
         <entry key="midas-config.schema">
           <value>
             <SchemaInfo>

--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ starting `midasd` webserver.
         // Main site will be generated to this directory. Default: public
         "build": "public",
         // Site with drafts will be generated to this directory. Default: publicDrafts
-        "draft": "publicDrafts"
+        "draft": "publicDrafts",
+        // The environment that should be passed to the generator. Default: development
+        "draftEnvironment": "development"
       },
       // You can specify deployment configuration to upload built site to the cloud.
       "deployment": {

--- a/aws/deployment.go
+++ b/aws/deployment.go
@@ -38,17 +38,22 @@ type Deployment struct {
 	cfClient  *cloudfront.Client
 }
 
-func New(site midas.Site, deploymentSettings midas.DeploymentSettings) (midas.Deployment, error) {
+func New(site midas.Site, deploymentSettings midas.DeploymentSettings, isDraft bool) (midas.Deployment, error) {
 	// Get build destination directory
-	var publicPath string
-	if site.OutputSettings.Build != "" {
+	var publicPath = filepath.Join(site.RootDir, "public")
+
+	if !isDraft && site.OutputSettings.Build != "" {
 		if filepath.IsAbs(site.OutputSettings.Build) {
 			publicPath = site.OutputSettings.Build
 		} else {
 			publicPath = filepath.Join(site.RootDir, site.OutputSettings.Build)
 		}
-	} else {
-		publicPath = filepath.Join(site.RootDir, "public")
+	} else if isDraft && site.OutputSettings.Draft != "" {
+		if filepath.IsAbs(site.OutputSettings.Draft) {
+			publicPath = site.OutputSettings.Draft
+		} else {
+			publicPath = filepath.Join(site.RootDir, site.OutputSettings.Draft)
+		}
 	}
 
 	cfg, err := config.LoadDefaultConfig(context.Background(),

--- a/cmd/midasSshTest/main.go
+++ b/cmd/midasSshTest/main.go
@@ -145,9 +145,9 @@ func (m *Main) Run(_ context.Context) (err error) {
 		},
 	}
 
-	midas.DeploymentTargets = map[string]func(site midas.Site, settings midas.DeploymentSettings) (midas.Deployment, error){
-		"aws": func(site midas.Site, settings midas.DeploymentSettings) (midas.Deployment, error) {
-			return aws.New(site, settings)
+	midas.DeploymentTargets = map[string]func(site midas.Site, settings midas.DeploymentSettings, isDraft bool) (midas.Deployment, error){
+		"aws": func(site midas.Site, settings midas.DeploymentSettings, isDraft bool) (midas.Deployment, error) {
+			return aws.New(site, settings, isDraft)
 		},
 	}
 
@@ -157,7 +157,7 @@ func (m *Main) Run(_ context.Context) (err error) {
 	if site := mapFirstEntry(m.Config.Sites); site == nil {
 		return fmt.Errorf("no sites configured")
 	} else {
-		deployment, err = sftp.New(*site, site.Deployment)
+		deployment, err = sftp.New(*site, site.Deployment, false)
 		if err != nil {
 			return err
 		}

--- a/cmd/midasd/main.go
+++ b/cmd/midasd/main.go
@@ -29,7 +29,15 @@ import (
 )
 
 var (
-	commit, version, date, environment string
+	commit, version, date, environment, logLevel string
+	logLevelAcceptedValues                       = map[string]struct{}{
+		"trace":    {},
+		"debug":    {},
+		"info":     {},
+		"warn":     {},
+		"error":    {},
+		"critical": {},
+	}
 )
 
 // main is the entry point of the application binary.
@@ -113,7 +121,7 @@ func NewMain() *Main {
 		Config:     defaultConfig(),
 		ConfigPath: defaultConfigPath,
 
-		HTTPServer: http.NewServer(false),
+		HTTPServer: http.NewServer(logLevel, false),
 	}
 }
 
@@ -132,9 +140,14 @@ func (m *Main) ParseFlags(_ context.Context, args []string) error {
 	fs := flag.NewFlagSet("midasd", flag.ContinueOnError)
 	fs.StringVar(&m.ConfigPath, "config", defaultConfigPath, "config path")
 	fs.StringVar(&environment, "env", "production", "app environment (development, production)")
+	fs.StringVar(&logLevel, "log", "info", "log level (trace, debug, info, warn, error, critical)")
 
 	if err := fs.Parse(args); err != nil {
 		return err
+	}
+
+	if _, ok := logLevelAcceptedValues[logLevel]; !ok {
+		logLevel = "info"
 	}
 
 	configPath, err := expand(m.ConfigPath)

--- a/cmd/midasd/main.go
+++ b/cmd/midasd/main.go
@@ -198,12 +198,12 @@ func (m *Main) Run(_ context.Context) (err error) {
 		},
 	}
 
-	midas.DeploymentTargets = map[string]func(site midas.Site, settings midas.DeploymentSettings) (midas.Deployment, error){
-		"aws": func(site midas.Site, settings midas.DeploymentSettings) (midas.Deployment, error) {
-			return aws.New(site, settings)
+	midas.DeploymentTargets = map[string]func(site midas.Site, settings midas.DeploymentSettings, isDraft bool) (midas.Deployment, error){
+		"aws": func(site midas.Site, settings midas.DeploymentSettings, isDraft bool) (midas.Deployment, error) {
+			return aws.New(site, settings, isDraft)
 		},
-		"sftp": func(site midas.Site, settings midas.DeploymentSettings) (midas.Deployment, error) {
-			return sftp.New(site, settings)
+		"sftp": func(site midas.Site, settings midas.DeploymentSettings, isDraft bool) (midas.Deployment, error) {
+			return sftp.New(site, settings, isDraft)
 		},
 	}
 

--- a/http/server.go
+++ b/http/server.go
@@ -37,14 +37,14 @@ type Server struct {
 	SiteServices map[string]func(site midas.Site) (midas.SiteService, error)
 }
 
-func NewServer(testing bool) *Server {
+func NewServer(logLevel string, testing bool) *Server {
 	s := &Server{
 		server:  &http.Server{},
 		router:  chi.NewRouter(),
 		testing: testing,
 	}
 
-	logger := httplog.NewLogger("midas", httplog.Options{Concise: true})
+	logger := httplog.NewLogger("midas", httplog.Options{Concise: true, LogLevel: logLevel})
 
 	if s.testing {
 		logger = logger.Output(zerolog.ConsoleWriter{Out: io.Discard})

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kovansky/midas"
 	midashttp "github.com/kovansky/midas/http"
 	"github.com/kovansky/midas/mock"
+	"github.com/rs/zerolog"
 	"io"
 	"net/http"
 	"testing"
@@ -67,7 +68,7 @@ func MustOpenServer(tb testing.TB, siteServices map[string]func(site midas.Site)
 	}
 
 	// Init wrapper and set test config settings.
-	s := &Server{Server: midashttp.NewServer(true)}
+	s := &Server{Server: midashttp.NewServer("trace", true)}
 
 	s.SiteServices = siteServices
 	s.Config = config
@@ -110,7 +111,7 @@ func SetUp(t *testing.T) *Server {
 		"hugo": func(site midas.Site) (midas.SiteService, error) {
 			siteService := mock.NewSiteService()
 
-			siteService.BuildSiteFn = func(useCache bool) error {
+			siteService.BuildSiteFn = func(useCache bool, _ zerolog.Logger) error {
 				MockSiteCounters["BuildSite"]++
 
 				return nil

--- a/http/strapi-hugo.go
+++ b/http/strapi-hugo.go
@@ -319,7 +319,7 @@ func (h StrapiToHugoHandler) deploy(cfg *midas.Site, draft bool) error {
 	if dpl, ok := midas.DeploymentTargets[dplSettings.Target]; ok {
 		var err error
 
-		if deploymentService, err = dpl(*cfg, dplSettings); err != nil {
+		if deploymentService, err = dpl(*cfg, dplSettings, draft); err != nil {
 			return midas.Errorf(midas.ErrInternal, "could not create deployment %s: %s", dplSettings.Target, err)
 		}
 	} else {

--- a/http/strapi-hugo.go
+++ b/http/strapi-hugo.go
@@ -126,7 +126,7 @@ func (s *Server) HandleHugoRebuild(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if err = hugoSite.BuildSite(useCache); err != nil {
+	if err = hugoSite.BuildSite(useCache, log); err != nil {
 		Error(w, r, err)
 		return
 	}
@@ -198,7 +198,7 @@ func (h StrapiToHugoHandler) handleCreateSingle(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	if err := h.HugoSite.BuildSite(true); err != nil {
+	if err := h.HugoSite.BuildSite(true, h.log); err != nil {
 		Error(w, r, err)
 		return
 	}
@@ -217,7 +217,7 @@ func (h StrapiToHugoHandler) handleCreateCollection(w http.ResponseWriter, r *ht
 		return
 	}
 
-	if err := h.HugoSite.BuildSite(true); err != nil {
+	if err := h.HugoSite.BuildSite(true, h.log); err != nil {
 		Error(w, r, err)
 		return
 	}
@@ -236,7 +236,7 @@ func (h StrapiToHugoHandler) handleUpdateSingle(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	if err := h.HugoSite.BuildSite(true); err != nil {
+	if err := h.HugoSite.BuildSite(true, h.log); err != nil {
 		Error(w, r, err)
 		return
 	}
@@ -255,7 +255,7 @@ func (h StrapiToHugoHandler) handleUpdateCollection(w http.ResponseWriter, r *ht
 		return
 	}
 
-	if err := h.HugoSite.BuildSite(true); err != nil {
+	if err := h.HugoSite.BuildSite(true, h.log); err != nil {
 		Error(w, r, err)
 		return
 	}
@@ -274,7 +274,7 @@ func (h StrapiToHugoHandler) handleDeleteCollection(w http.ResponseWriter, r *ht
 		return
 	}
 
-	if err := h.HugoSite.BuildSite(true); err != nil {
+	if err := h.HugoSite.BuildSite(true, h.log); err != nil {
 		Error(w, r, err)
 		return
 	}

--- a/hugo/site.go
+++ b/hugo/site.go
@@ -53,13 +53,6 @@ func (s SiteService) GetRegistryService() (midas.RegistryService, error) {
 func (s SiteService) BuildSite(useCache bool, log zerolog.Logger) error {
 	var arg = s.constructBuildArgs(useCache, false)
 
-	log.Debug().
-		Fields(map[string]interface{}{
-			"cmd":  "hugo",
-			"args": arg,
-		}).
-		Msgf("Build command")
-
 	cmd := exec.Command("hugo", arg...)
 	cmd.Dir = s.Site.RootDir
 

--- a/hugo/site.go
+++ b/hugo/site.go
@@ -86,11 +86,17 @@ func (s SiteService) constructBuildArgs(useCache, isDraft bool) (arg []string) {
 		}
 	} else {
 		arg = append(arg, "-d")
-
 		if s.Site.OutputSettings.Draft != "" {
 			arg = append(arg, s.Site.OutputSettings.Draft)
 		} else {
 			arg = append(arg, "publicDrafts")
+		}
+
+		arg = append(arg, "-e")
+		if s.Site.OutputSettings.DraftEnvironment != "" {
+			arg = append(arg, s.Site.OutputSettings.DraftEnvironment)
+		} else {
+			arg = append(arg, "development")
 		}
 
 		// -D is for build drafts, -E for build expired, -F for build future

--- a/hugo/site.go
+++ b/hugo/site.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/kovansky/midas"
+	"github.com/rs/zerolog"
 	"html/template"
 	"os"
 	"os/exec"
@@ -49,8 +50,15 @@ func (s SiteService) GetRegistryService() (midas.RegistryService, error) {
 	return s.registry, nil
 }
 
-func (s SiteService) BuildSite(useCache bool) error {
+func (s SiteService) BuildSite(useCache bool, log zerolog.Logger) error {
 	var arg = s.constructBuildArgs(useCache, false)
+
+	log.Debug().
+		Fields(map[string]interface{}{
+			"cmd":  "hugo",
+			"args": arg,
+		}).
+		Msgf("Build command")
 
 	cmd := exec.Command("hugo", arg...)
 	cmd.Dir = s.Site.RootDir

--- a/midas-config.schema.json
+++ b/midas-config.schema.json
@@ -56,6 +56,11 @@
                 "draft": {
                   "type": "string",
                   "description": "The directory where the builds containing drafts (site previews) output should be stored. Default value depends on the service"
+                },
+                "draftEnvironment": {
+                  "type": "string",
+                  "description": "The environment that should be passed to the generator. Default: development",
+                  "default": "development"
                 }
               }
             },

--- a/midas.go
+++ b/midas.go
@@ -16,7 +16,7 @@ var (
 	Version string
 
 	RegistryServices  map[string]func(site Site) RegistryService
-	DeploymentTargets map[string]func(site Site, settings DeploymentSettings) (Deployment, error)
+	DeploymentTargets map[string]func(site Site, settings DeploymentSettings, isDraft bool) (Deployment, error)
 	Sanitizer         SanitizerService
 )
 

--- a/mock/site.go
+++ b/mock/site.go
@@ -6,14 +6,17 @@
 
 package mock
 
-import "github.com/kovansky/midas"
+import (
+	"github.com/kovansky/midas"
+	"github.com/rs/zerolog"
+)
 
 var _ midas.SiteService = (*SiteService)(nil)
 
 type SiteService struct {
 	GetRegistryServiceFn func() (midas.RegistryService, error)
 	CreateRegistryFn     func() (string, error)
-	BuildSiteFn          func(useCache bool) error
+	BuildSiteFn          func(useCache bool, log zerolog.Logger) error
 	CreateEntryFn        func(payload midas.Payload) (string, error)
 	UpdateEntryFn        func(payload midas.Payload) (string, error)
 	DeleteEntryFn        func(payload midas.Payload) (string, error)
@@ -28,8 +31,8 @@ func (s *SiteService) GetRegistryService() (midas.RegistryService, error) {
 	return s.GetRegistryServiceFn()
 }
 
-func (s *SiteService) BuildSite(useCache bool) error {
-	return s.BuildSiteFn(useCache)
+func (s *SiteService) BuildSite(useCache bool, log zerolog.Logger) error {
+	return s.BuildSiteFn(useCache, log)
 }
 
 func (s *SiteService) CreateEntry(payload midas.Payload) (string, error) {

--- a/sftp/deployment.go
+++ b/sftp/deployment.go
@@ -24,17 +24,22 @@ type Deployment struct {
 	sftpClient Client
 }
 
-func New(site midas.Site, deploymentSettings midas.DeploymentSettings) (midas.Deployment, error) {
+func New(site midas.Site, deploymentSettings midas.DeploymentSettings, isDraft bool) (midas.Deployment, error) {
 	// Get build destination directory
-	var publicPath string
-	if site.OutputSettings.Build != "" {
+	var publicPath = filepath.Join(site.RootDir, "public")
+
+	if !isDraft && site.OutputSettings.Build != "" {
 		if filepath.IsAbs(site.OutputSettings.Build) {
 			publicPath = site.OutputSettings.Build
 		} else {
 			publicPath = filepath.Join(site.RootDir, site.OutputSettings.Build)
 		}
-	} else {
-		publicPath = filepath.Join(site.RootDir, "public")
+	} else if isDraft && site.OutputSettings.Draft != "" {
+		if filepath.IsAbs(site.OutputSettings.Draft) {
+			publicPath = site.OutputSettings.Draft
+		} else {
+			publicPath = filepath.Join(site.RootDir, site.OutputSettings.Draft)
+		}
 	}
 
 	sftpClient := *NewClient(deploymentSettings.SFTP)

--- a/site.go
+++ b/site.go
@@ -25,8 +25,9 @@ type Site struct {
 }
 
 type OutputSettings struct {
-	Build string `json:"build,omitempty"`
-	Draft string `json:"draft,omitempty"`
+	Build            string `json:"build,omitempty"`
+	Draft            string `json:"draft,omitempty"`
+	DraftEnvironment string `json:"draftEnvironment,omitempty"`
 }
 
 type ModelSettings struct {

--- a/site.go
+++ b/site.go
@@ -6,6 +6,8 @@
 
 package midas
 
+import "github.com/rs/zerolog"
+
 type Site struct {
 	SiteName string `json:"siteName"`
 	Service  string `json:"service"`
@@ -46,7 +48,7 @@ type RegistrySettings struct {
 
 type SiteService interface {
 	GetRegistryService() (RegistryService, error)
-	BuildSite(useCache bool) error
+	BuildSite(useCache bool, log zerolog.Logger) error
 	CreateEntry(payload Payload) (string, error)
 	UpdateEntry(payload Payload) (string, error)
 	DeleteEntry(payload Payload) (string, error)


### PR DESCRIPTION
## Added
- Possibility to specify draft build environment (production, development) [editable as `site.outputSettings.draftEnvironment` in `config.json`]
- `log` CLI argument - specify log level

## Changed
- Added debug log on hugo build command