### PR TITLE
[CI] Update goreleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,10 +24,12 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
-    replacements:
-      darwin: mac
-      386: i386
-      amd64: x86_64
+    name_template: >-
+      {{- .ProjectName }}_
+      {{- .Version }}_
+      {{- if eq .Os "darwin" }}mac{{ else }}{{ .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- if eq .Arch "386" }}i386
 
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
## Changed

- Goreleaser `archives.replacements` option is depreciated, use `name_template` instead